### PR TITLE
remove trailing space and add a blank line after the banner

### DIFF
--- a/src/banner.js
+++ b/src/banner.js
@@ -37,9 +37,9 @@ export default class BannerPlugin {
         for (let i = 0; i < arr.length; i++) {
           let item = arr[i]
           if (i === 0) {
-            text += '/** \n * ' + item + '\n'
+            text += '/**\n * ' + item + '\n'
           } else if (i === arr.length - 1) {
-            text += ' * ' + item + '\n */\n'
+            text += ' * ' + item + '\n */\n\n'
           } else {
             text += ' * ' + item + '\n'
           }


### PR DESCRIPTION
let's remove the trailing space after `/**` and add a blank line after the banner — this way Prettier formatting will not trigger any errors on it