### PR TITLE
fix: vulnerabilities in lodash.template < 4.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3100,20 +3100,20 @@
       "dev": true
     },
     "lodash.template": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.4.0.tgz",
-      "integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.5.0.tgz",
+      "integrity": "sha512-84vYFxIkmidUiFxidA/KjjH9pAycqW+h980j7Fuz5qxRtO9pgB7MDFTdys1N7A5mcucRiDyEq4fusljItR1T/A==",
       "requires": {
-        "lodash._reinterpolate": "~3.0.0",
+        "lodash._reinterpolate": "^3.0.0",
         "lodash.templatesettings": "^4.0.0"
       }
     },
     "lodash.templatesettings": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz",
-      "integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.2.0.tgz",
+      "integrity": "sha512-stgLz+i3Aa9mZgnjr/O+v9ruKZsPsndy7qPZOchbqk2cnTU1ZaldKK+v7m54WoKIyxiuMZTKT2H81F8BeAc3ZQ==",
       "requires": {
-        "lodash._reinterpolate": "~3.0.0"
+        "lodash._reinterpolate": "^3.0.0"
       }
     },
     "loose-envify": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,6 @@
     "rollup": "^1.1.0"
   },
   "dependencies": {
-    "lodash.template": "^4.4.0"
+    "lodash.template": "^4.5.0"
   }
 }


### PR DESCRIPTION
There is a vulnerability in `"lodash.template" < "^4.5.0"`. To get rid of security alerts, we should use `4.5.0` version at least

```
CVE-2019-10744 More information
critical severity
Vulnerable versions: < 4.5.0
Patched version: 4.5.0
Affected versions of lodash are vulnerable to Prototype Pollution.
The function defaultsDeep could be tricked into adding or modifying properties of Object.prototype using a constructor payload.
```
https://nvd.nist.gov/vuln/detail/CVE-2019-10744